### PR TITLE
#964 eas-cli-build エラーに対応

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -22,7 +22,7 @@ export default ({ config }: ConfigContext) => {
 			githubUrl: 'https://github.com/Ayato-kosaka/spelieve',
 			orientation: 'portrait',
 			userInterfaceStyle: 'light',
-			backgroundColor: '#ffffff',
+			// backgroundColor @see {@link https://docs.expo.dev/versions/latest/config/app/#backgroundColor}
 			// primaryColor @see {@link https://docs.expo.dev/versions/latest/config/app/#primaryColor}
 			icon: './assets/favicon.png',
 			// notification @see {@link https://docs.expo.dev/versions/latest/config/app/#notification}


### PR DESCRIPTION
ios: ios.backgroundColor: Install expo-system-ui to enable this feature https://docs.expo.dev/build-reference/migrating/#expo-config--backgroundcolor--depends-on